### PR TITLE
Added commands in README.md for ots installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ You need to install `praw` (for the Reddit API) and `ots` (for summarization).
     pip install praw
     
 To install ots, do the following :
+    
     sudo apt-get install libots
 
     sudo apt-get install libots-dev

--- a/README.md
+++ b/README.md
@@ -10,9 +10,14 @@ Installation
 You need to install `praw` (for the Reddit API) and `ots` (for summarization).
 
     pip install praw
+    
+To install ots, do the following :
+    sudo apt-get install libots
+
+    sudo apt-get install libots-dev
+	
     pip install ots
 
-OTS is a bit difficult to install.
 
 Configuration
 -------------


### PR DESCRIPTION
These two commands followed by `pip install` will install ots.